### PR TITLE
 DRY up IncomeExpenditure model tests

### DIFF
--- a/spec/models/income_expenditure_spec.rb
+++ b/spec/models/income_expenditure_spec.rb
@@ -1,7 +1,8 @@
-# spec/models/income_expenditure_spec.rb
 require 'rails_helper'
 
 RSpec.describe IncomeExpenditure, type: :model do
+  let(:user) { FactoryBot.create(:user) }
+
   describe 'associations' do
     it { is_expected.to have_one(:income).dependent(:destroy) }
     it { is_expected.to have_one(:expenditure).dependent(:destroy) }
@@ -13,17 +14,38 @@ RSpec.describe IncomeExpenditure, type: :model do
     it { is_expected.to validate_presence_of(:person_name) }
   end
 
-  describe 'methods' do
-    let(:valid_income_expenditure) do
-      FactoryBot.create(:income_expenditure, income: FactoryBot.build(:income, salary: 3000, other: 500))
+  describe 'I.E ratings' do
+    shared_examples 'calculates disposable income and rating' do |expenditures, income, expected_income, expected_rating|
+      let!(:valid_income_expenditure) do
+        valid_income = user.income_expenditures.create(person_name: 'anu')
+        valid_income.create_expenditure!(expenditures)
+        valid_income.create_income!(income)
+        valid_income.reload
+      end
+
+      it 'calculates disposable income' do
+        expect(valid_income_expenditure.disposable_income).to eq(expected_income)
+      end
+
+      it 'calculates rating' do
+        expect(valid_income_expenditure.rating).to eq(expected_rating)
+      end
     end
 
-    it 'calculates disposable income' do
-      expect(valid_income_expenditure.disposable_income).to eq(2500)
+    context 'when rating is A' do
+      include_examples 'calculates disposable income and rating', { mortgage: 0, utilities: 0, travel: 0, food: 0, loan_repayment: 0 }, { salary: 2000, other: 0 }, 2000, 'A'
     end
 
-    it 'calculates rating' do
-      expect(valid_income_expenditure.rating).to eq('D')
+    context 'when rating is B' do
+      include_examples 'calculates disposable income and rating', { mortgage: 100, utilities: 100, travel: 100, food: 0, loan_repayment: 0 }, { salary: 2000, other: 0 }, 1700.0, 'B'
+    end
+
+    context 'when rating is C' do
+      include_examples 'calculates disposable income and rating', { mortgage: 200, utilities: 200, travel: 100, food: 100, loan_repayment: 100 }, { salary: 2000, other: 0 }, 1300.0, 'C'
+    end
+
+    context 'when rating is D' do
+      include_examples 'calculates disposable income and rating', { mortgage: 500, utilities: 200, travel: 200, food: 300, loan_repayment: 400 }, { salary: 2000, other: 0 }, 400.0, 'D'
     end
   end
 end


### PR DESCRIPTION
- Consolidate common test logic into shared examples
- Improve organization and readability of tests
- Use shared examples and contexts for I.E rating scenarios including A, B, C and D ratings

This commit streamlines the model tests for the IncomeExpenditure class by utilizing shared examples and contexts. The shared examples encapsulate the logic for calculating disposable income and rating, promoting code reuse and maintainability.